### PR TITLE
Add classic mode easter egg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ default-run = "spelunkicons"
 name = "spelunkicons"
 path = "src/lib.rs"
 
-
 [[bin]]
 name = "spelunkicons"
 path = "src/main.rs"
@@ -31,3 +30,6 @@ itertools = "0.10.3"
 rand = "0.8.4"
 tokio = { version = "1", features = ["full"] }
 url = "2.2.2"
+
+[build-dependencies]
+image = "0.23.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/bruteforce.rs"
 
 [dependencies]
 bitvec = "1.0.0"
+multimap = "0.8.3"
 clap = { version = "3.0.13", features = ["derive"] }
 crc32fast = "1.3.1"
 hyper = { version = "0.14", features = ["full"] }

--- a/build.rs
+++ b/build.rs
@@ -48,6 +48,11 @@ static PNGS: &'static [(&str, &str, Option<(u32, u32, u32, u32)>)] = &[
     ("BASECAMP_DECO", "deco_basecamp.png", Option::None),
     ("ITEMS", "items.png", Option::None),
     (
+        "CHAR_PRECIOUS",
+        "monstersbasic02.png",
+        Option::Some((1 * 128, 7 * 128, 128, 128)),
+    ),
+    (
         "CHAR_BEG",
         "monstersbasic03.png",
         Option::Some((6 * 128, 4 * 128, 128, 128)),

--- a/build.rs
+++ b/build.rs
@@ -47,6 +47,11 @@ static PNGS: &'static [(&str, &str, Option<(u32, u32, u32, u32)>)] = &[
     ("FLOORMISC", "floormisc.png", Option::None),
     ("BASECAMP_DECO", "deco_basecamp.png", Option::None),
     ("ITEMS", "items.png", Option::None),
+    (
+        "CHAR_BEG",
+        "monstersbasic03.png",
+        Option::Some((6 * 128, 4 * 128, 128, 128)),
+    ),
 ];
 
 fn main() {

--- a/build.rs
+++ b/build.rs
@@ -1,37 +1,52 @@
 use std::env;
 use std::fs;
 use std::fs::File;
-use std::io::Write;
+use std::io::{BufReader, Cursor, Read, Write};
 use std::path::Path;
 use std::path::PathBuf;
 
-static PNGS: &'static [(&str, &str)] = &[
-    ("FLOOR_CAVE", "floor_cave.png"),
-    ("FLOOR_JUNGLE", "floor_jungle.png"),
-    ("FLOOR_BABYLON", "floor_babylon.png"),
-    ("FLOOR_EGGPLANT", "floor_eggplant.png"),
-    ("FLOOR_ICE", "floor_ice.png"),
-    ("FLOOR_SUNKEN", "floor_sunken.png"),
-    ("FLOOR_SURFACE", "floor_surface.png"),
-    ("FLOOR_TEMPLE", "floor_temple.png"),
-    ("FLOOR_TIDEPOOL", "floor_tidepool.png"),
-    ("FLOOR_VOLCANO", "floor_volcano.png"),
-    ("FLOORSTYLED_BABYLON", "floorstyled_babylon.png"),
-    ("FLOORSTYLED_BEEHIVE", "floorstyled_beehive.png"),
-    ("FLOORSTYLED_DUAT", "floorstyled_duat.png"),
-    ("FLOORSTYLED_GOLD", "floorstyled_gold.png"),
-    ("FLOORSTYLED_GUTS", "floorstyled_guts.png"),
-    ("FLOORSTYLED_MOTHERSHIP", "floorstyled_mothership.png"),
-    ("FLOORSTYLED_PAGODA", "floorstyled_pagoda.png"),
-    ("FLOORSTYLED_PALACE", "floorstyled_palace.png"),
-    ("FLOORSTYLED_STONE", "floorstyled_stone.png"),
-    ("FLOORSTYLED_SUNKEN", "floorstyled_sunken.png"),
-    ("FLOORSTYLED_TEMPLE", "floorstyled_temple.png"),
-    ("FLOORSTYLED_VLAD", "floorstyled_vlad.png"),
-    ("FLOORSTYLED_WOOD", "floorstyled_wood.png"),
-    ("FLOORMISC", "floormisc.png"),
-    ("BASECAMP_DECO", "deco_basecamp.png"),
-    ("ITEMS", "items.png"),
+use image::ImageFormat::Png;
+use image::{load_from_memory_with_format, DynamicImage, GenericImageView};
+
+static PNGS: &'static [(&str, &str, Option<(u32, u32, u32, u32)>)] = &[
+    ("FLOOR_CAVE", "floor_cave.png", Option::None),
+    ("FLOOR_JUNGLE", "floor_jungle.png", Option::None),
+    ("FLOOR_BABYLON", "floor_babylon.png", Option::None),
+    ("FLOOR_EGGPLANT", "floor_eggplant.png", Option::None),
+    ("FLOOR_ICE", "floor_ice.png", Option::None),
+    ("FLOOR_SUNKEN", "floor_sunken.png", Option::None),
+    ("FLOOR_SURFACE", "floor_surface.png", Option::None),
+    ("FLOOR_TEMPLE", "floor_temple.png", Option::None),
+    ("FLOOR_TIDEPOOL", "floor_tidepool.png", Option::None),
+    ("FLOOR_VOLCANO", "floor_volcano.png", Option::None),
+    (
+        "FLOORSTYLED_BABYLON",
+        "floorstyled_babylon.png",
+        Option::None,
+    ),
+    (
+        "FLOORSTYLED_BEEHIVE",
+        "floorstyled_beehive.png",
+        Option::None,
+    ),
+    ("FLOORSTYLED_DUAT", "floorstyled_duat.png", Option::None),
+    ("FLOORSTYLED_GOLD", "floorstyled_gold.png", Option::None),
+    ("FLOORSTYLED_GUTS", "floorstyled_guts.png", Option::None),
+    (
+        "FLOORSTYLED_MOTHERSHIP",
+        "floorstyled_mothership.png",
+        Option::None,
+    ),
+    ("FLOORSTYLED_PAGODA", "floorstyled_pagoda.png", Option::None),
+    ("FLOORSTYLED_PALACE", "floorstyled_palace.png", Option::None),
+    ("FLOORSTYLED_STONE", "floorstyled_stone.png", Option::None),
+    ("FLOORSTYLED_SUNKEN", "floorstyled_sunken.png", Option::None),
+    ("FLOORSTYLED_TEMPLE", "floorstyled_temple.png", Option::None),
+    ("FLOORSTYLED_VLAD", "floorstyled_vlad.png", Option::None),
+    ("FLOORSTYLED_WOOD", "floorstyled_wood.png", Option::None),
+    ("FLOORMISC", "floormisc.png", Option::None),
+    ("BASECAMP_DECO", "deco_basecamp.png", Option::None),
+    ("ITEMS", "items.png", Option::None),
 ];
 
 fn main() {
@@ -51,29 +66,67 @@ fn main() {
 
     let mut out_file = File::create(&dest_path).unwrap();
 
-    for (name, path) in PNGS {
+    for (name, path, region) in PNGS {
         for (prefix, root) in &texture_roots {
             let path = root.join(path);
-            let metadata = fs::metadata(&path).unwrap_or_else(|err| {
-                panic!(
-                    "Error loading metadata of file {}: {:?}",
-                    path.to_string_lossy(),
-                    err
-                )
-            });
 
-            out_file
-                .write(
-                    format!(
-                        "pub static {}{}: &'static [u8; {}] = include_bytes!({:?});\n",
-                        prefix,
-                        name,
-                        metadata.len(),
-                        &path
-                    )
-                    .as_bytes(),
-                )
-                .unwrap();
+            match region {
+                Some(region) => {
+                    let bytes = {
+                        let file = File::open(&path).unwrap_or_else(|err| {
+                            panic!("Error opening file {}: {:?}", path.to_string_lossy(), err)
+                        });
+                        let mut reader = BufReader::new(file);
+                        let mut buffer = Vec::new();
+                        reader.read_to_end(&mut buffer).unwrap_or_else(|err| {
+                            panic!("Error reading file {}: {:?}", path.to_string_lossy(), err)
+                        });
+                        buffer
+                    };
+                    let image = load_from_memory_with_format(&bytes, Png).unwrap();
+                    let (x, y, w, h) = region.clone();
+                    let subimage = DynamicImage::ImageRgba8(image.view(x, y, w, h).to_image());
+
+                    let mut out_bytes: Vec<u8> = Vec::new();
+                    subimage
+                        .write_to(&mut Cursor::new(&mut out_bytes), Png)
+                        .unwrap_or_else(|err| panic!("Error writing subimage: {:?}", err));
+                    out_file
+                        .write(
+                            format!(
+                                "pub static {}{}: &'static [u8; {}] = &{:?};\n",
+                                prefix,
+                                name,
+                                out_bytes.len(),
+                                out_bytes
+                            )
+                            .as_bytes(),
+                        )
+                        .unwrap();
+                }
+                None => {
+                    let metadata = fs::metadata(&path).unwrap_or_else(|err| {
+                        panic!(
+                            "Error loading metadata of file {}: {:?}",
+                            path.to_string_lossy(),
+                            err
+                        )
+                    });
+
+                    out_file
+                        .write(
+                            format!(
+                                "pub static {}{}: &'static [u8; {}] = include_bytes!({:?});\n",
+                                prefix,
+                                name,
+                                metadata.len(),
+                                &path
+                            )
+                            .as_bytes(),
+                        )
+                        .unwrap();
+                }
+            }
         }
     }
     println!("cargo:rerun-if-changed=build.rs");

--- a/src/egg_renderer.rs
+++ b/src/egg_renderer.rs
@@ -10,9 +10,15 @@ use crate::grid_renderer::Sheets;
 use crate::sheets::Biome;
 use crate::spelunkicon::Spelunkicon;
 
-pub struct PrideRenderer {}
+pub struct PrideRenderer {
+    classic_mode: bool,
+}
 
 impl PrideRenderer {
+    pub fn new(classic_mode: bool) -> Self {
+        return Self { classic_mode };
+    }
+
     fn render_pansexual_flag(
         &self,
         base_image: &mut RgbaImage,
@@ -25,7 +31,7 @@ impl PrideRenderer {
         // Tiles
         {
             let guts_tile = sheets
-                .sheet_floorstyled_from_biome(&Biome::Guts)
+                .sheet_floorstyled_from_biome(&Biome::Guts, self.classic_mode)
                 .unwrap()
                 .view(1 * TILE_WIDTH, 4 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             let y = 0 * TILE_HEIGHT;
@@ -37,7 +43,7 @@ impl PrideRenderer {
 
         {
             let gold_tile = sheets
-                .sheet_floorstyled_from_biome(&Biome::CityOfGold)
+                .sheet_floorstyled_from_biome(&Biome::CityOfGold, self.classic_mode)
                 .unwrap()
                 .view(1 * TILE_WIDTH, 5 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             let y = 1 * TILE_HEIGHT;
@@ -49,7 +55,7 @@ impl PrideRenderer {
 
         {
             let tidepool_tile = sheets
-                .sheet_floor_from_biome(&Biome::TidePool)
+                .sheet_floor_from_biome(&Biome::TidePool, self.classic_mode)
                 .unwrap()
                 .view(0 * TILE_WIDTH, 0 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             let y = 2 * TILE_HEIGHT;
@@ -61,7 +67,9 @@ impl PrideRenderer {
 
         // Decos
         {
-            let tide_pool = &sheets.sheet_floor_from_biome(&Biome::TidePool).unwrap();
+            let tide_pool = &sheets
+                .sheet_floor_from_biome(&Biome::TidePool, self.classic_mode)
+                .unwrap();
             let up_deco = vec![
                 tide_pool.view(5 * TILE_WIDTH, 6 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT),
                 tide_pool.view(6 * TILE_WIDTH, 6 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT),
@@ -90,7 +98,9 @@ impl PrideRenderer {
         let w = config.grid_width as u32;
 
         // Tiles
-        let sunken_sheet = sheets.sheet_floor_from_biome(&Biome::Sunken).unwrap();
+        let sunken_sheet = sheets
+            .sheet_floor_from_biome(&Biome::Sunken, self.classic_mode)
+            .unwrap();
 
         {
             let pipes_tile =
@@ -104,7 +114,7 @@ impl PrideRenderer {
 
         {
             let palace_tile = sheets
-                .sheet_floorstyled_from_biome(&Biome::PalaceOfPleasure)
+                .sheet_floorstyled_from_biome(&Biome::PalaceOfPleasure, self.classic_mode)
                 .unwrap()
                 .view(1 * TILE_WIDTH, 5 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             let y = 1 * TILE_HEIGHT;
@@ -156,7 +166,7 @@ impl PrideRenderer {
         // Tiles
         {
             let gold_tile = sheets
-                .sheet_floorstyled_from_biome(&Biome::CityOfGold)
+                .sheet_floorstyled_from_biome(&Biome::CityOfGold, self.classic_mode)
                 .unwrap()
                 .view(1 * TILE_WIDTH, 4 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             let y = 0 * TILE_HEIGHT;
@@ -168,7 +178,7 @@ impl PrideRenderer {
 
         {
             let palace_tile = sheets
-                .sheet_floorstyled_from_biome(&Biome::PalaceOfPleasure)
+                .sheet_floorstyled_from_biome(&Biome::PalaceOfPleasure, self.classic_mode)
                 .unwrap()
                 .view(1 * TILE_WIDTH, 5 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             let y = 1 * TILE_HEIGHT;
@@ -180,7 +190,7 @@ impl PrideRenderer {
 
         {
             let babylon_tile = sheets
-                .sheet_floorstyled_from_biome(&Biome::Babylon)
+                .sheet_floorstyled_from_biome(&Biome::Babylon, self.classic_mode)
                 .unwrap()
                 .view(1 * TILE_WIDTH, 5 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             let y = 2 * TILE_HEIGHT;
@@ -192,7 +202,7 @@ impl PrideRenderer {
 
         {
             let duat_tile = sheets
-                .sheet_floorstyled_from_biome(&Biome::Duat)
+                .sheet_floorstyled_from_biome(&Biome::Duat, self.classic_mode)
                 .unwrap()
                 .view(1 * TILE_WIDTH, 2 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             let y = 3 * TILE_HEIGHT;
@@ -217,7 +227,7 @@ impl PrideRenderer {
         // Tiles
         {
             let duat_tile = sheets
-                .sheet_floorstyled_from_biome(&Biome::Duat)
+                .sheet_floorstyled_from_biome(&Biome::Duat, self.classic_mode)
                 .unwrap()
                 .view(1 * TILE_WIDTH, 4 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             let y = 0 * TILE_HEIGHT;
@@ -229,7 +239,7 @@ impl PrideRenderer {
 
         {
             let stone_tile = sheets
-                .sheet_floorstyled_from_biome(&Biome::Olmec)
+                .sheet_floorstyled_from_biome(&Biome::Olmec, self.classic_mode)
                 .unwrap()
                 .view(1 * TILE_WIDTH, 5 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             let y = 1 * TILE_HEIGHT;
@@ -241,7 +251,7 @@ impl PrideRenderer {
 
         {
             let palace_tile = sheets
-                .sheet_floorstyled_from_biome(&Biome::PalaceOfPleasure)
+                .sheet_floorstyled_from_biome(&Biome::PalaceOfPleasure, self.classic_mode)
                 .unwrap()
                 .view(1 * TILE_WIDTH, 5 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             let y = 2 * TILE_HEIGHT;
@@ -253,7 +263,7 @@ impl PrideRenderer {
 
         {
             let eggplant_tile = sheets
-                .sheet_floor_from_biome(&Biome::Eggplant)
+                .sheet_floor_from_biome(&Biome::Eggplant, self.classic_mode)
                 .unwrap()
                 .view(1 * TILE_WIDTH, 3 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             let y = 3 * TILE_HEIGHT;
@@ -265,7 +275,9 @@ impl PrideRenderer {
 
         // Decos
         {
-            let eggplant = &sheets.sheet_floor_from_biome(&Biome::Eggplant).unwrap();
+            let eggplant = &sheets
+                .sheet_floor_from_biome(&Biome::Eggplant, self.classic_mode)
+                .unwrap();
             let up_deco = vec![
                 eggplant.view(5 * TILE_WIDTH, 6 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT),
                 eggplant.view(6 * TILE_WIDTH, 6 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT),
@@ -296,7 +308,7 @@ impl PrideRenderer {
         // Tiles
         {
             let surface_tile = sheets
-                .sheet_floor_from_biome(&Biome::Surface)
+                .sheet_floor_from_biome(&Biome::Surface, self.classic_mode)
                 .unwrap()
                 .view(0 * TILE_WIDTH, 0 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             let y_top = 0 * TILE_HEIGHT;
@@ -310,7 +322,7 @@ impl PrideRenderer {
 
         {
             let guts_tile = sheets
-                .sheet_floorstyled_from_biome(&Biome::Guts)
+                .sheet_floorstyled_from_biome(&Biome::Guts, self.classic_mode)
                 .unwrap()
                 .view(1 * TILE_WIDTH, 5 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             let y_top = 1 * TILE_HEIGHT;
@@ -324,7 +336,7 @@ impl PrideRenderer {
 
         {
             let palace_tile = sheets
-                .sheet_floorstyled_from_biome(&Biome::PalaceOfPleasure)
+                .sheet_floorstyled_from_biome(&Biome::PalaceOfPleasure, self.classic_mode)
                 .unwrap()
                 .view(1 * TILE_WIDTH, 5 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             let y = 2 * TILE_HEIGHT;
@@ -336,7 +348,9 @@ impl PrideRenderer {
 
         // Decos
         {
-            let surface = &sheets.sheet_floor_from_biome(&Biome::Surface).unwrap();
+            let surface = &sheets
+                .sheet_floor_from_biome(&Biome::Surface, self.classic_mode)
+                .unwrap();
             let up_deco = vec![
                 surface.view(5 * TILE_WIDTH, 6 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT),
                 surface.view(6 * TILE_WIDTH, 6 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT),
@@ -378,7 +392,9 @@ impl PrideRenderer {
 
         // Tiles
         {
-            let guts_sheet = sheets.sheet_floorstyled_from_biome(&Biome::Guts).unwrap();
+            let guts_sheet = sheets
+                .sheet_floorstyled_from_biome(&Biome::Guts, self.classic_mode)
+                .unwrap();
             let guts_bot =
                 guts_sheet.view(1 * TILE_WIDTH, 4 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             let guts_top =
@@ -394,7 +410,7 @@ impl PrideRenderer {
 
         {
             let eggplant_tile = sheets
-                .sheet_floor_from_biome(&Biome::Eggplant)
+                .sheet_floor_from_biome(&Biome::Eggplant, self.classic_mode)
                 .unwrap()
                 .view(0 * TILE_WIDTH, 0 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             let y = 2 * TILE_HEIGHT;
@@ -406,7 +422,7 @@ impl PrideRenderer {
 
         {
             let babylon_sheet = sheets
-                .sheet_floorstyled_from_biome(&Biome::Babylon)
+                .sheet_floorstyled_from_biome(&Biome::Babylon, self.classic_mode)
                 .unwrap();
             let babylon_bot =
                 babylon_sheet.view(1 * TILE_WIDTH, 3 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
@@ -423,7 +439,9 @@ impl PrideRenderer {
 
         // Decos
         {
-            let eggplant = &sheets.sheet_floor_from_biome(&Biome::Eggplant).unwrap();
+            let eggplant = &sheets
+                .sheet_floor_from_biome(&Biome::Eggplant, self.classic_mode)
+                .unwrap();
             let up_deco = vec![
                 eggplant.view(5 * TILE_WIDTH, 6 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT),
                 eggplant.view(6 * TILE_WIDTH, 6 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT),
@@ -466,7 +484,7 @@ impl PrideRenderer {
         // Tiles
         {
             let vlad_tile = sheets
-                .sheet_floorstyled_from_biome(&Biome::Vlad)
+                .sheet_floorstyled_from_biome(&Biome::Vlad, self.classic_mode)
                 .unwrap()
                 .view(1 * TILE_WIDTH, 5 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             let y = 0 * TILE_HEIGHT;
@@ -477,12 +495,10 @@ impl PrideRenderer {
         }
 
         {
-            let cave_tile = sheets.sheet_floor_from_biome(&Biome::Cave).unwrap().view(
-                0 * TILE_WIDTH,
-                0 * TILE_HEIGHT,
-                TILE_WIDTH,
-                TILE_HEIGHT,
-            );
+            let cave_tile = sheets
+                .sheet_floor_from_biome(&Biome::Cave, self.classic_mode)
+                .unwrap()
+                .view(0 * TILE_WIDTH, 0 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             let y = 1 * TILE_HEIGHT;
             for i in 0..w {
                 let x = i * TILE_WIDTH;
@@ -492,7 +508,7 @@ impl PrideRenderer {
 
         {
             let gold_tile = sheets
-                .sheet_floorstyled_from_biome(&Biome::CityOfGold)
+                .sheet_floorstyled_from_biome(&Biome::CityOfGold, self.classic_mode)
                 .unwrap()
                 .view(1 * TILE_WIDTH, 5 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             let y = 2 * TILE_HEIGHT;
@@ -503,12 +519,10 @@ impl PrideRenderer {
         }
 
         {
-            let jungle_tile = sheets.sheet_floor_from_biome(&Biome::Jungle).unwrap().view(
-                0 * TILE_WIDTH,
-                0 * TILE_HEIGHT,
-                TILE_WIDTH,
-                TILE_HEIGHT,
-            );
+            let jungle_tile = sheets
+                .sheet_floor_from_biome(&Biome::Jungle, self.classic_mode)
+                .unwrap()
+                .view(0 * TILE_WIDTH, 0 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             let y = 3 * TILE_HEIGHT;
             for i in 0..w {
                 let x = i * TILE_WIDTH;
@@ -518,7 +532,7 @@ impl PrideRenderer {
 
         {
             let pagoda_tile = sheets
-                .sheet_floorstyled_from_biome(&Biome::TidePool)
+                .sheet_floorstyled_from_biome(&Biome::TidePool, self.classic_mode)
                 .unwrap()
                 .view(1 * TILE_WIDTH, 5 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             let y = 4 * TILE_HEIGHT;
@@ -530,7 +544,7 @@ impl PrideRenderer {
 
         {
             let eggplant_tile = sheets
-                .sheet_floor_from_biome(&Biome::Eggplant)
+                .sheet_floor_from_biome(&Biome::Eggplant, self.classic_mode)
                 .unwrap()
                 .view(0 * TILE_WIDTH, 0 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             let y = 5 * TILE_HEIGHT;
@@ -542,7 +556,9 @@ impl PrideRenderer {
 
         // Decos
         {
-            let cave = &sheets.sheet_floor_from_biome(&Biome::Cave).unwrap();
+            let cave = &sheets
+                .sheet_floor_from_biome(&Biome::Cave, self.classic_mode)
+                .unwrap();
             let up_deco = vec![
                 cave.view(5 * TILE_WIDTH, 6 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT),
                 cave.view(6 * TILE_WIDTH, 6 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT),
@@ -572,7 +588,9 @@ impl PrideRenderer {
         }
 
         {
-            let jungle = &sheets.sheet_floor_from_biome(&Biome::Jungle).unwrap();
+            let jungle = &sheets
+                .sheet_floor_from_biome(&Biome::Jungle, self.classic_mode)
+                .unwrap();
             let up_deco = vec![
                 jungle.view(5 * TILE_WIDTH, 6 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT),
                 jungle.view(6 * TILE_WIDTH, 6 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT),
@@ -602,7 +620,9 @@ impl PrideRenderer {
         }
 
         {
-            let eggplant = &sheets.sheet_floor_from_biome(&Biome::Eggplant).unwrap();
+            let eggplant = &sheets
+                .sheet_floor_from_biome(&Biome::Eggplant, self.classic_mode)
+                .unwrap();
             let up_deco = vec![
                 eggplant.view(5 * TILE_WIDTH, 6 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT),
                 eggplant.view(6 * TILE_WIDTH, 6 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT),
@@ -632,7 +652,9 @@ impl PrideRenderer {
 
         // Tiles
         {
-            let duat_sheet = sheets.sheet_floorstyled_from_biome(&Biome::Duat).unwrap();
+            let duat_sheet = sheets
+                .sheet_floorstyled_from_biome(&Biome::Duat, self.classic_mode)
+                .unwrap();
             let duat_top =
                 duat_sheet.view(1 * TILE_WIDTH, 4 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             let duat_bot =
@@ -648,7 +670,7 @@ impl PrideRenderer {
 
         {
             let stone_tile = sheets
-                .sheet_floorstyled_from_biome(&Biome::Olmec)
+                .sheet_floorstyled_from_biome(&Biome::Olmec, self.classic_mode)
                 .unwrap()
                 .view(1 * TILE_WIDTH, 5 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             let y_top = 1 * TILE_HEIGHT;
@@ -662,7 +684,7 @@ impl PrideRenderer {
 
         {
             let palace_tile = sheets
-                .sheet_floorstyled_from_biome(&Biome::PalaceOfPleasure)
+                .sheet_floorstyled_from_biome(&Biome::PalaceOfPleasure, self.classic_mode)
                 .unwrap()
                 .view(1 * TILE_WIDTH, 5 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             let y_top = 2 * TILE_HEIGHT;
@@ -675,12 +697,10 @@ impl PrideRenderer {
         }
 
         {
-            let vines = sheets.sheet_floor_from_biome(&Biome::Jungle).unwrap().view(
-                8 * TILE_WIDTH,
-                11 * TILE_HEIGHT,
-                TILE_WIDTH,
-                TILE_HEIGHT,
-            );
+            let vines = sheets
+                .sheet_floor_from_biome(&Biome::Jungle, self.classic_mode)
+                .unwrap()
+                .view(8 * TILE_WIDTH, 11 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             let y = 3 * TILE_HEIGHT;
             for i in 0..w {
                 let x = i * TILE_WIDTH;
@@ -690,7 +710,9 @@ impl PrideRenderer {
 
         // Decos
         {
-            let jungle = &sheets.sheet_floor_from_biome(&Biome::Jungle).unwrap();
+            let jungle = &sheets
+                .sheet_floor_from_biome(&Biome::Jungle, self.classic_mode)
+                .unwrap();
             let up_deco = jungle.view(11 * TILE_WIDTH, 6 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             let down_deco = jungle.view(11 * TILE_WIDTH, 7 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             let y = 3 * TILE_HEIGHT;
@@ -715,7 +737,7 @@ impl PrideRenderer {
         // Tiles
         {
             let gold_tile = sheets
-                .sheet_floorstyled_from_biome(&Biome::CityOfGold)
+                .sheet_floorstyled_from_biome(&Biome::CityOfGold, self.classic_mode)
                 .unwrap()
                 .view(1 * TILE_WIDTH, 3 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             for i in 0..w {
@@ -731,7 +753,7 @@ impl PrideRenderer {
         {
             let hue_rotate = -140;
 
-            let deco_sheet = &sheets.get_basecamp_deco();
+            let deco_sheet = &sheets.get_basecamp_deco(self.classic_mode);
             let dragon_head = deco_sheet
                 .view(
                     7 * TILE_WIDTH,
@@ -814,7 +836,7 @@ impl PrideRenderer {
         // Tiles
         {
             let duat_tile = sheets
-                .sheet_floorstyled_from_biome(&Biome::Duat)
+                .sheet_floorstyled_from_biome(&Biome::Duat, self.classic_mode)
                 .unwrap()
                 .view(1 * TILE_WIDTH, 4 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             let y = 0 * TILE_HEIGHT;
@@ -826,7 +848,7 @@ impl PrideRenderer {
 
         {
             let wood_tile = sheets
-                .sheet_floorstyled_from_biome(&Biome::Cave)
+                .sheet_floorstyled_from_biome(&Biome::Cave, self.classic_mode)
                 .unwrap()
                 .view(1 * TILE_WIDTH, 5 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             let y = 1 * TILE_HEIGHT;
@@ -838,7 +860,7 @@ impl PrideRenderer {
 
         {
             let vlad_tile = sheets
-                .sheet_floorstyled_from_biome(&Biome::Vlad)
+                .sheet_floorstyled_from_biome(&Biome::Vlad, self.classic_mode)
                 .unwrap()
                 .view(1 * TILE_WIDTH, 5 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             let y = 2 * TILE_HEIGHT;
@@ -849,12 +871,10 @@ impl PrideRenderer {
         }
 
         {
-            let cave_tile = sheets.sheet_floor_from_biome(&Biome::Cave).unwrap().view(
-                0 * TILE_WIDTH,
-                0 * TILE_HEIGHT,
-                TILE_WIDTH,
-                TILE_HEIGHT,
-            );
+            let cave_tile = sheets
+                .sheet_floor_from_biome(&Biome::Cave, self.classic_mode)
+                .unwrap()
+                .view(0 * TILE_WIDTH, 0 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             let y = 3 * TILE_HEIGHT;
             for i in 0..w {
                 let x = i * TILE_WIDTH;
@@ -864,7 +884,7 @@ impl PrideRenderer {
 
         {
             let gold_tile = sheets
-                .sheet_floorstyled_from_biome(&Biome::CityOfGold)
+                .sheet_floorstyled_from_biome(&Biome::CityOfGold, self.classic_mode)
                 .unwrap()
                 .view(1 * TILE_WIDTH, 5 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             let y = 4 * TILE_HEIGHT;
@@ -875,12 +895,10 @@ impl PrideRenderer {
         }
 
         {
-            let jungle_tile = sheets.sheet_floor_from_biome(&Biome::Jungle).unwrap().view(
-                0 * TILE_WIDTH,
-                0 * TILE_HEIGHT,
-                TILE_WIDTH,
-                TILE_HEIGHT,
-            );
+            let jungle_tile = sheets
+                .sheet_floor_from_biome(&Biome::Jungle, self.classic_mode)
+                .unwrap()
+                .view(0 * TILE_WIDTH, 0 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             let y = 5 * TILE_HEIGHT;
             for i in 0..w {
                 let x = i * TILE_WIDTH;
@@ -890,7 +908,7 @@ impl PrideRenderer {
 
         {
             let pagoda_tile = sheets
-                .sheet_floorstyled_from_biome(&Biome::TidePool)
+                .sheet_floorstyled_from_biome(&Biome::TidePool, self.classic_mode)
                 .unwrap()
                 .view(1 * TILE_WIDTH, 5 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             let y = 6 * TILE_HEIGHT;
@@ -902,7 +920,7 @@ impl PrideRenderer {
 
         {
             let eggplant_tile = sheets
-                .sheet_floor_from_biome(&Biome::Eggplant)
+                .sheet_floor_from_biome(&Biome::Eggplant, self.classic_mode)
                 .unwrap()
                 .view(0 * TILE_WIDTH, 0 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT);
             let y = 7 * TILE_HEIGHT;
@@ -914,7 +932,9 @@ impl PrideRenderer {
 
         // Decos
         {
-            let cave = &sheets.sheet_floor_from_biome(&Biome::Cave).unwrap();
+            let cave = &sheets
+                .sheet_floor_from_biome(&Biome::Cave, self.classic_mode)
+                .unwrap();
             let up_deco = vec![
                 cave.view(5 * TILE_WIDTH, 6 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT),
                 cave.view(6 * TILE_WIDTH, 6 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT),
@@ -944,7 +964,9 @@ impl PrideRenderer {
         }
 
         {
-            let jungle = &sheets.sheet_floor_from_biome(&Biome::Jungle).unwrap();
+            let jungle = &sheets
+                .sheet_floor_from_biome(&Biome::Jungle, self.classic_mode)
+                .unwrap();
             let up_deco = vec![
                 jungle.view(5 * TILE_WIDTH, 6 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT),
                 jungle.view(6 * TILE_WIDTH, 6 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT),
@@ -974,7 +996,9 @@ impl PrideRenderer {
         }
 
         {
-            let eggplant = &sheets.sheet_floor_from_biome(&Biome::Eggplant).unwrap();
+            let eggplant = &sheets
+                .sheet_floor_from_biome(&Biome::Eggplant, self.classic_mode)
+                .unwrap();
             let up_deco = vec![
                 eggplant.view(5 * TILE_WIDTH, 6 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT),
                 eggplant.view(6 * TILE_WIDTH, 6 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT),

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -57,21 +57,19 @@ impl Generator {
         let mut rng = StdRng::seed_from_u64(config.hash as u64);
         let sheet_idx = rng.gen::<usize>() % self.sheet_gens.len();
 
+        let egg = config.egg.clone().unwrap_or_else(Vec::<String>::new);
+
         // Note intentionally doing rng first so that the manual classic mode has same rng as random classic mode
-        let classic_mode =
-            rng.gen_bool(0.01) || config.egg == Option::Some(String::from("classic"));
+        let classic_mode = rng.gen_bool(0.01) || egg.contains(&String::from("classic"));
 
         // Generate Image
-        match config.egg.as_deref() {
-            Option::Some("pride") => {
-                let sheet = GenSheet::new(GenKind::Pride, Biome::Cave);
-                sheet.generate_image(&mut image, &self.sheets, &config, classic_mode, &mut rng);
-            }
-            _ => {
-                let sheet = &self.sheet_gens[sheet_idx];
-                sheet.generate_image(&mut image, &self.sheets, &config, classic_mode, &mut rng);
-            }
-        };
+        if egg.contains(&String::from("pride")) {
+            let sheet = GenSheet::new(GenKind::Pride, Biome::Cave);
+            sheet.generate_image(&mut image, &self.sheets, &config, classic_mode, &mut rng);
+        } else {
+            let sheet = &self.sheet_gens[sheet_idx];
+            sheet.generate_image(&mut image, &self.sheets, &config, classic_mode, &mut rng);
+        }
 
         let image = resize(
             &image,

--- a/src/grid_renderer.rs
+++ b/src/grid_renderer.rs
@@ -6,7 +6,7 @@ use rand::prelude::*;
 
 use crate::constants::{TILE_HEIGHT, TILE_WIDTH};
 use crate::grid_generator::*;
-use crate::pngs;
+use crate::pngs::*;
 use crate::sheets::Biome;
 use crate::spelunkicon::Spelunkicon;
 
@@ -182,126 +182,151 @@ fn get_floor_styled_texture_coords(neighbour_mask: u8) -> (u32, u32) {
 }
 
 pub struct Sheets {
-    floor_cave: DynamicImage,
-    floor_jungle: DynamicImage,
-    floor_babylon: DynamicImage,
-    floor_eggplant: DynamicImage,
-    floor_ice: DynamicImage,
-    floor_sunken: DynamicImage,
-    floor_surface: DynamicImage,
-    floor_temple: DynamicImage,
-    floor_tidepool: DynamicImage,
-    floor_volcano: DynamicImage,
+    floor_cave: [DynamicImage; 2],
+    floor_jungle: [DynamicImage; 2],
+    floor_babylon: [DynamicImage; 2],
+    floor_eggplant: [DynamicImage; 2],
+    floor_ice: [DynamicImage; 2],
+    floor_sunken: [DynamicImage; 2],
+    floor_surface: [DynamicImage; 2],
+    floor_temple: [DynamicImage; 2],
+    floor_tidepool: [DynamicImage; 2],
+    floor_volcano: [DynamicImage; 2],
 
-    floorstyled_vlad: DynamicImage,
-    floorstyled_wood: DynamicImage,
-    floorstyled_babylon: DynamicImage,
-    floorstyled_beehive: DynamicImage,
-    floorstyled_duat: DynamicImage,
-    floorstyled_gold: DynamicImage,
-    floorstyled_guts: DynamicImage,
-    floorstyled_mothership: DynamicImage,
-    floorstyled_pagoda: DynamicImage,
-    floorstyled_palace: DynamicImage,
-    floorstyled_stone: DynamicImage,
-    floorstyled_sunken: DynamicImage,
-    floorstyled_temple: DynamicImage,
+    floorstyled_vlad: [DynamicImage; 2],
+    floorstyled_wood: [DynamicImage; 2],
+    floorstyled_babylon: [DynamicImage; 2],
+    floorstyled_beehive: [DynamicImage; 2],
+    floorstyled_duat: [DynamicImage; 2],
+    floorstyled_gold: [DynamicImage; 2],
+    floorstyled_guts: [DynamicImage; 2],
+    floorstyled_mothership: [DynamicImage; 2],
+    floorstyled_pagoda: [DynamicImage; 2],
+    floorstyled_palace: [DynamicImage; 2],
+    floorstyled_stone: [DynamicImage; 2],
+    floorstyled_sunken: [DynamicImage; 2],
+    floorstyled_temple: [DynamicImage; 2],
 
-    floormisc: DynamicImage,
-    basecamp_deco: DynamicImage,
+    floormisc: [DynamicImage; 2],
+    basecamp_deco: [DynamicImage; 2],
 
-    items: DynamicImage,
+    items: [DynamicImage; 2],
+}
+
+fn load_images(spel2_data: &[u8], classic_data: &[u8]) -> [DynamicImage; 2] {
+    [
+        load_from_memory_with_format(spel2_data, Png).unwrap(),
+        load_from_memory_with_format(classic_data, Png).unwrap(),
+    ]
 }
 
 impl Sheets {
     pub fn new() -> Self {
         Self {
-            floor_cave: load_from_memory_with_format(pngs::FLOOR_CAVE, Png).unwrap(),
-            floor_jungle: load_from_memory_with_format(pngs::FLOOR_JUNGLE, Png).unwrap(),
-            floor_babylon: load_from_memory_with_format(pngs::FLOOR_BABYLON, Png).unwrap(),
-            floor_eggplant: load_from_memory_with_format(pngs::FLOOR_EGGPLANT, Png).unwrap(),
-            floor_ice: load_from_memory_with_format(pngs::FLOOR_ICE, Png).unwrap(),
-            floor_sunken: load_from_memory_with_format(pngs::FLOOR_SUNKEN, Png).unwrap(),
-            floor_surface: load_from_memory_with_format(pngs::FLOOR_SURFACE, Png).unwrap(),
-            floor_temple: load_from_memory_with_format(pngs::FLOOR_TEMPLE, Png).unwrap(),
-            floor_tidepool: load_from_memory_with_format(pngs::FLOOR_TIDEPOOL, Png).unwrap(),
-            floor_volcano: load_from_memory_with_format(pngs::FLOOR_VOLCANO, Png).unwrap(),
+            floor_cave: load_images(FLOOR_CAVE, CLASSIC_FLOOR_CAVE),
+            floor_jungle: load_images(FLOOR_JUNGLE, CLASSIC_FLOOR_JUNGLE),
+            floor_babylon: load_images(FLOOR_BABYLON, CLASSIC_FLOOR_BABYLON),
+            floor_eggplant: load_images(FLOOR_EGGPLANT, CLASSIC_FLOOR_EGGPLANT),
+            floor_ice: load_images(FLOOR_ICE, CLASSIC_FLOOR_ICE),
+            floor_sunken: load_images(FLOOR_SUNKEN, CLASSIC_FLOOR_SUNKEN),
+            floor_surface: load_images(FLOOR_SURFACE, CLASSIC_FLOOR_SURFACE),
+            floor_temple: load_images(FLOOR_TEMPLE, CLASSIC_FLOOR_TEMPLE),
+            floor_tidepool: load_images(FLOOR_TIDEPOOL, CLASSIC_FLOOR_TIDEPOOL),
+            floor_volcano: load_images(FLOOR_VOLCANO, CLASSIC_FLOOR_VOLCANO),
 
-            floorstyled_vlad: load_from_memory_with_format(pngs::FLOORSTYLED_VLAD, Png).unwrap(),
-            floorstyled_wood: load_from_memory_with_format(pngs::FLOORSTYLED_WOOD, Png).unwrap(),
-            floorstyled_babylon: load_from_memory_with_format(pngs::FLOORSTYLED_BABYLON, Png)
-                .unwrap(),
-            floorstyled_beehive: load_from_memory_with_format(pngs::FLOORSTYLED_BEEHIVE, Png)
-                .unwrap(),
-            floorstyled_duat: load_from_memory_with_format(pngs::FLOORSTYLED_DUAT, Png).unwrap(),
-            floorstyled_gold: load_from_memory_with_format(pngs::FLOORSTYLED_GOLD, Png).unwrap(),
-            floorstyled_guts: load_from_memory_with_format(pngs::FLOORSTYLED_GUTS, Png).unwrap(),
-            floorstyled_mothership: load_from_memory_with_format(pngs::FLOORSTYLED_MOTHERSHIP, Png)
-                .unwrap(),
-            floorstyled_pagoda: load_from_memory_with_format(pngs::FLOORSTYLED_PAGODA, Png)
-                .unwrap(),
-            floorstyled_palace: load_from_memory_with_format(pngs::FLOORSTYLED_PALACE, Png)
-                .unwrap(),
-            floorstyled_stone: load_from_memory_with_format(pngs::FLOORSTYLED_STONE, Png).unwrap(),
-            floorstyled_sunken: load_from_memory_with_format(pngs::FLOORSTYLED_SUNKEN, Png)
-                .unwrap(),
-            floorstyled_temple: load_from_memory_with_format(pngs::FLOORSTYLED_TEMPLE, Png)
-                .unwrap(),
+            floorstyled_vlad: load_images(FLOORSTYLED_VLAD, CLASSIC_FLOORSTYLED_VLAD),
+            floorstyled_wood: load_images(FLOORSTYLED_WOOD, CLASSIC_FLOORSTYLED_WOOD),
+            floorstyled_babylon: load_images(FLOORSTYLED_BABYLON, CLASSIC_FLOORSTYLED_BABYLON),
+            floorstyled_beehive: load_images(FLOORSTYLED_BEEHIVE, CLASSIC_FLOORSTYLED_BEEHIVE),
+            floorstyled_duat: load_images(FLOORSTYLED_DUAT, CLASSIC_FLOORSTYLED_DUAT),
+            floorstyled_gold: load_images(FLOORSTYLED_GOLD, CLASSIC_FLOORSTYLED_GOLD),
+            floorstyled_guts: load_images(FLOORSTYLED_GUTS, CLASSIC_FLOORSTYLED_GUTS),
+            floorstyled_mothership: load_images(
+                FLOORSTYLED_MOTHERSHIP,
+                CLASSIC_FLOORSTYLED_MOTHERSHIP,
+            ),
+            floorstyled_pagoda: load_images(FLOORSTYLED_PAGODA, CLASSIC_FLOORSTYLED_PAGODA),
+            floorstyled_palace: load_images(FLOORSTYLED_PALACE, CLASSIC_FLOORSTYLED_PALACE),
+            floorstyled_stone: load_images(FLOORSTYLED_STONE, CLASSIC_FLOORSTYLED_STONE),
+            floorstyled_sunken: load_images(FLOORSTYLED_SUNKEN, CLASSIC_FLOORSTYLED_SUNKEN),
+            floorstyled_temple: load_images(FLOORSTYLED_TEMPLE, CLASSIC_FLOORSTYLED_TEMPLE),
+            floormisc: load_images(FLOORMISC, CLASSIC_FLOORMISC),
+            basecamp_deco: load_images(BASECAMP_DECO, CLASSIC_BASECAMP_DECO),
 
-            floormisc: load_from_memory_with_format(pngs::FLOORMISC, Png).unwrap(),
-            basecamp_deco: load_from_memory_with_format(pngs::BASECAMP_DECO, Png).unwrap(),
-
-            items: load_from_memory_with_format(pngs::ITEMS, Png).unwrap(),
+            items: load_images(ITEMS, CLASSIC_ITEMS),
         }
     }
 
-    pub fn sheet_floor_from_biome(&self, biome: &Biome) -> Option<&DynamicImage> {
+    pub fn sheet_floor_from_biome(&self, biome: &Biome, classic: bool) -> Option<&DynamicImage> {
+        let idx = if classic { 1 } else { 0 };
         match biome {
-            Biome::Cave => Some(&self.floor_cave),
-            Biome::Jungle | Biome::Beehive => Some(&self.floor_jungle),
-            Biome::Babylon => Some(&self.floor_babylon),
-            Biome::Eggplant => Some(&self.floor_eggplant),
-            Biome::Ice => Some(&self.floor_ice),
-            Biome::Sunken => Some(&self.floor_sunken),
-            Biome::Surface => Some(&self.floor_surface),
-            Biome::Temple => Some(&self.floor_temple),
-            Biome::TidePool => Some(&self.floor_tidepool),
-            Biome::Volcana => Some(&self.floor_volcano),
+            Biome::Cave => Some(&self.floor_cave[idx]),
+            Biome::Jungle | Biome::Beehive => Some(&self.floor_jungle[idx]),
+            Biome::Babylon => Some(&self.floor_babylon[idx]),
+            Biome::Eggplant => Some(&self.floor_eggplant[idx]),
+            Biome::Ice => Some(&self.floor_ice[idx]),
+            Biome::Sunken => Some(&self.floor_sunken[idx]),
+            Biome::Surface => Some(&self.floor_surface[idx]),
+            Biome::Temple => Some(&self.floor_temple[idx]),
+            Biome::TidePool => Some(&self.floor_tidepool[idx]),
+            Biome::Volcana => Some(&self.floor_volcano[idx]),
 
             _ => None,
         }
     }
 
-    pub fn sheet_floorstyled_from_biome(&self, biome: &Biome) -> Option<&DynamicImage> {
+    pub fn sheet_floorstyled_from_biome(
+        &self,
+        biome: &Biome,
+        classic: bool,
+    ) -> Option<&DynamicImage> {
+        let idx = if classic { 1 } else { 0 };
         match biome {
-            Biome::Cave => Some(&self.floorstyled_wood),
-            Biome::Jungle => Some(&self.floorstyled_stone),
-            Biome::Babylon => Some(&self.floorstyled_babylon),
-            Biome::Sunken => Some(&self.floorstyled_sunken),
-            Biome::Temple => Some(&self.floorstyled_temple),
-            Biome::TidePool => Some(&self.floorstyled_pagoda),
+            Biome::Cave => Some(&self.floorstyled_wood[idx]),
+            Biome::Jungle => Some(&self.floorstyled_stone[idx]),
+            Biome::Babylon => Some(&self.floorstyled_babylon[idx]),
+            Biome::Sunken => Some(&self.floorstyled_sunken[idx]),
+            Biome::Temple => Some(&self.floorstyled_temple[idx]),
+            Biome::TidePool => Some(&self.floorstyled_pagoda[idx]),
 
-            Biome::Beehive => Some(&self.floorstyled_beehive),
-            Biome::Vlad => Some(&self.floorstyled_vlad),
-            Biome::CityOfGold => Some(&self.floorstyled_gold),
-            Biome::Duat => Some(&self.floorstyled_duat),
-            Biome::Mothership => Some(&self.floorstyled_mothership),
-            Biome::PalaceOfPleasure => Some(&self.floorstyled_palace),
-            Biome::Guts => Some(&self.floorstyled_guts),
-            Biome::Olmec => Some(&self.floorstyled_stone),
+            Biome::Beehive => Some(&self.floorstyled_beehive[idx]),
+            Biome::Vlad => Some(&self.floorstyled_vlad[idx]),
+            Biome::CityOfGold => Some(&self.floorstyled_gold[idx]),
+            Biome::Duat => Some(&self.floorstyled_duat[idx]),
+            Biome::Mothership => Some(&self.floorstyled_mothership[idx]),
+            Biome::PalaceOfPleasure => Some(&self.floorstyled_palace[idx]),
+            Biome::Guts => Some(&self.floorstyled_guts[idx]),
+            Biome::Olmec => Some(&self.floorstyled_stone[idx]),
 
             _ => None,
         }
     }
 
-    pub fn get_basecamp_deco(&self) -> &DynamicImage {
-        return &self.basecamp_deco;
+    pub fn get_floormisc(&self, classic: bool) -> &DynamicImage {
+        let idx = if classic { 1 } else { 0 };
+        return &self.floormisc[idx];
+    }
+
+    pub fn get_basecamp_deco(&self, classic: bool) -> &DynamicImage {
+        let idx = if classic { 1 } else { 0 };
+        return &self.basecamp_deco[idx];
+    }
+
+    pub fn get_items(&self, classic: bool) -> &DynamicImage {
+        let idx = if classic { 1 } else { 0 };
+        return &self.items[idx];
     }
 }
 
-pub struct GridRenderer {}
+pub struct GridRenderer {
+    classic_mode: bool,
+}
 
 impl GridRenderer {
+    pub fn new(classic_mode: bool) -> Self {
+        return Self { classic_mode };
+    }
+
     fn base_tiles<'a>(&self, image: &'a DynamicImage) -> Vec<SubImage<&'a DynamicImage>> {
         return vec![
             image.view(0, 0, TILE_WIDTH, TILE_HEIGHT),
@@ -320,7 +345,9 @@ impl GridRenderer {
         rng: &mut StdRng,
         grid: &PlacedTileGrid,
     ) {
-        let sheet_image = sheets.sheet_floor_from_biome(biome).unwrap();
+        let sheet_image = sheets
+            .sheet_floor_from_biome(biome, self.classic_mode)
+            .unwrap();
 
         let tile_images = self.base_tiles(sheet_image);
 
@@ -346,7 +373,9 @@ impl GridRenderer {
         _rng: &mut StdRng,
         grid: &PlacedTileGrid,
     ) {
-        let sheet_image = sheets.sheet_floorstyled_from_biome(biome).unwrap();
+        let sheet_image = sheets
+            .sheet_floorstyled_from_biome(biome, self.classic_mode)
+            .unwrap();
 
         for (row_idx, row) in grid.iter().enumerate() {
             for (col_idx, tile) in row.iter().enumerate() {
@@ -402,13 +431,21 @@ impl GridRenderer {
         rng: &mut StdRng,
         grid: &PlacedTileGrid,
     ) {
-        let floormisc = &sheets.floormisc;
+        let floormisc = sheets.get_floormisc(self.classic_mode);
         let biome_sheet = sheets
-            .sheet_floor_from_biome(biome)
-            .unwrap_or(&sheets.floor_cave);
+            .sheet_floor_from_biome(biome, self.classic_mode)
+            .unwrap_or(
+                sheets
+                    .sheet_floor_from_biome(&Biome::Cave, self.classic_mode)
+                    .unwrap(),
+            );
         let floorstyled_biome_sheet = sheets
-            .sheet_floorstyled_from_biome(biome)
-            .unwrap_or(&sheets.floorstyled_stone);
+            .sheet_floorstyled_from_biome(biome, self.classic_mode)
+            .unwrap_or(
+                sheets
+                    .sheet_floorstyled_from_biome(&Biome::Olmec, self.classic_mode)
+                    .unwrap(),
+            );
 
         for (row_idx, row) in grid.iter().enumerate() {
             for (col_idx, tile) in row.iter().enumerate() {
@@ -438,7 +475,7 @@ impl GridRenderer {
                     PlacedTile::IdolAltarRight => {
                         place_tile(biome_sheet, 11, 0);
 
-                        let tile_image = sheets.items.view(
+                        let tile_image = sheets.get_items(self.classic_mode).view(
                             15 * TILE_WIDTH,
                             1 * TILE_HEIGHT,
                             TILE_WIDTH,
@@ -621,7 +658,13 @@ impl GridRenderer {
                         }
                     }
                     PlacedTile::UdjatSocketBot => {
-                        place_tile(&sheets.floorstyled_babylon, 7, 2);
+                        place_tile(
+                            &sheets
+                                .sheet_floorstyled_from_biome(&Biome::Babylon, self.classic_mode)
+                                .unwrap(),
+                            7,
+                            2,
+                        );
                     }
                     PlacedTile::ConveyorLeft => {
                         place_tile(biome_sheet, 11, 11);
@@ -632,7 +675,9 @@ impl GridRenderer {
                     PlacedTile::PushBlock => {
                         let sheet = match biome {
                             Biome::CityOfGold | Biome::Duat => floorstyled_biome_sheet,
-                            Biome::Surface => &sheets.floor_cave,
+                            Biome::Surface => sheets
+                                .sheet_floor_from_biome(&Biome::Cave, self.classic_mode)
+                                .unwrap(),
                             _ => biome_sheet,
                         };
                         let (ix, iy) = match biome {
@@ -645,7 +690,7 @@ impl GridRenderer {
                         place_tile(floormisc, 2, 2);
                     }
                     PlacedTile::HoneyUp => {
-                        let tile_image = sheets.items.view(
+                        let tile_image = sheets.get_items(self.classic_mode).view(
                             14 * TILE_WIDTH,
                             14 * TILE_HEIGHT,
                             TILE_WIDTH,
@@ -654,7 +699,7 @@ impl GridRenderer {
                         overlay(base_image, &tile_image, x, y - 22);
                     }
                     PlacedTile::HoneyDown => {
-                        let tile_image = sheets.items.view(
+                        let tile_image = sheets.get_items(self.classic_mode).view(
                             13 * TILE_WIDTH,
                             14 * TILE_HEIGHT,
                             TILE_WIDTH,
@@ -677,7 +722,9 @@ impl GridRenderer {
         rng: &mut StdRng,
         grid: &PlacedTileGrid,
     ) {
-        let sheet_image = sheets.sheet_floor_from_biome(biome).unwrap();
+        let sheet_image = sheets
+            .sheet_floor_from_biome(biome, self.classic_mode)
+            .unwrap();
 
         let right_deco = vec![
             sheet_image.view(5 * TILE_WIDTH, 5 * TILE_HEIGHT, TILE_WIDTH, TILE_HEIGHT),
@@ -791,13 +838,16 @@ impl GridRenderer {
                         }
                     }
                     PlacedTile::BoneBlock => {
-                        let left_deco = sheets.floor_cave.view(
+                        let floor_cave = sheets
+                            .sheet_floor_from_biome(&Biome::Cave, self.classic_mode)
+                            .unwrap();
+                        let left_deco = floor_cave.view(
                             10 * TILE_WIDTH,
                             3 * TILE_HEIGHT,
                             TILE_WIDTH,
                             TILE_HEIGHT,
                         );
-                        let right_deco = sheets.floor_cave.view(
+                        let right_deco = floor_cave.view(
                             11 * TILE_WIDTH,
                             3 * TILE_HEIGHT,
                             TILE_WIDTH,
@@ -816,7 +866,7 @@ impl GridRenderer {
                             Some(PlacedTile::BoneBlock),
                         );
                         if up_empty || up_bone {
-                            let up_deco = sheets.floor_cave.view(
+                            let up_deco = floor_cave.view(
                                 11 * TILE_WIDTH,
                                 2 * TILE_HEIGHT,
                                 TILE_WIDTH,
@@ -825,13 +875,14 @@ impl GridRenderer {
                             overlay(base_image, &up_deco, x, y - (TILE_HEIGHT / 2));
                         }
                         if up_empty && rng.gen_bool(0.5) {
-                            let ribcage = sheets.items.view(
+                            let items = sheets.get_items(self.classic_mode);
+                            let ribcage = items.view(
                                 14 * TILE_WIDTH,
                                 3 * TILE_HEIGHT,
                                 TILE_WIDTH,
                                 TILE_HEIGHT,
                             );
-                            let skull = sheets.items.view(
+                            let skull = items.view(
                                 15 * TILE_WIDTH,
                                 3 * TILE_HEIGHT,
                                 TILE_WIDTH,
@@ -842,19 +893,22 @@ impl GridRenderer {
                         }
                     }
                     PlacedTile::BushBlock => {
-                        let left_deco = sheets.floor_jungle.view(
+                        let floor_jungle = sheets
+                            .sheet_floor_from_biome(&Biome::Jungle, self.classic_mode)
+                            .unwrap();
+                        let left_deco = floor_jungle.view(
                             10 * TILE_WIDTH,
                             3 * TILE_HEIGHT,
                             TILE_WIDTH,
                             TILE_HEIGHT,
                         );
-                        let right_deco = sheets.floor_jungle.view(
+                        let right_deco = floor_jungle.view(
                             11 * TILE_WIDTH,
                             3 * TILE_HEIGHT,
                             TILE_WIDTH,
                             TILE_HEIGHT,
                         );
-                        let down_deco = sheets.floor_jungle.view(
+                        let down_deco = floor_jungle.view(
                             10 * TILE_WIDTH,
                             4 * TILE_HEIGHT,
                             TILE_WIDTH,
@@ -874,7 +928,7 @@ impl GridRenderer {
                                 Some(PlacedTile::BushBlock),
                             );
                         if up {
-                            let up_deco = sheets.floor_jungle.view(
+                            let up_deco = floor_jungle.view(
                                 11 * TILE_WIDTH,
                                 2 * TILE_HEIGHT,
                                 TILE_WIDTH,
@@ -897,29 +951,17 @@ impl GridRenderer {
         rng: &mut StdRng,
         grid: &PlacedTileGrid,
     ) {
+        let items = sheets.get_items(self.classic_mode);
         let crust_gold = vec![
-            sheets
-                .items
-                .view(TILE_WIDTH * 10, 0, TILE_WIDTH, TILE_HEIGHT),
-            sheets
-                .items
-                .view(TILE_WIDTH * 11, 0, TILE_WIDTH, TILE_HEIGHT),
+            items.view(TILE_WIDTH * 10, 0, TILE_WIDTH, TILE_HEIGHT),
+            items.view(TILE_WIDTH * 11, 0, TILE_WIDTH, TILE_HEIGHT),
         ];
         let crust_jewels = vec![
-            sheets
-                .items
-                .view(TILE_WIDTH * 3, 0, TILE_WIDTH, TILE_HEIGHT),
-            sheets
-                .items
-                .view(TILE_WIDTH * 4, 0, TILE_WIDTH, TILE_HEIGHT),
-            sheets
-                .items
-                .view(TILE_WIDTH * 5, 0, TILE_WIDTH, TILE_HEIGHT),
+            items.view(TILE_WIDTH * 3, 0, TILE_WIDTH, TILE_HEIGHT),
+            items.view(TILE_WIDTH * 4, 0, TILE_WIDTH, TILE_HEIGHT),
+            items.view(TILE_WIDTH * 5, 0, TILE_WIDTH, TILE_HEIGHT),
         ];
-        let crust_jetpack =
-            sheets
-                .items
-                .view(TILE_WIDTH * 9, TILE_HEIGHT * 2, TILE_WIDTH, TILE_HEIGHT);
+        let crust_jetpack = items.view(TILE_WIDTH * 9, TILE_HEIGHT * 2, TILE_WIDTH, TILE_HEIGHT);
 
         for (row_idx, row) in config.grid.iter().enumerate() {
             for (col_idx, col) in row.iter().enumerate() {

--- a/src/grid_renderer.rs
+++ b/src/grid_renderer.rs
@@ -447,6 +447,8 @@ impl GridRenderer {
                     .unwrap(),
             );
 
+        let mut placed_egg = false;
+
         for (row_idx, row) in grid.iter().enumerate() {
             for (col_idx, tile) in row.iter().enumerate() {
                 let x = col_idx as u32 * TILE_HEIGHT as u32;
@@ -569,6 +571,22 @@ impl GridRenderer {
                         place_tile(biome_sheet, 10, 2);
                     }
                     PlacedTile::IceBlock => {
+                        if !placed_egg && rng.gen_bool(0.2) {
+                            let beg_image = load_from_memory_with_format(
+                                if self.classic_mode {
+                                    CLASSIC_CHAR_BEG
+                                } else {
+                                    CHAR_BEG
+                                },
+                                Png,
+                            )
+                            .unwrap();
+
+                            overlay(base_image, &beg_image, x, y);
+
+                            placed_egg = true;
+                        }
+
                         let tile_image = biome_sheet.view(
                             7 * TILE_WIDTH,
                             1 * TILE_HEIGHT,
@@ -578,11 +596,16 @@ impl GridRenderer {
                         let tile_image = DynamicImage::ImageRgba8(tile_image.to_image());
 
                         let overlap = 8;
-                        let tile_image = tile_image.resize(
+                        let mut tile_image = tile_image.resize(
                             TILE_WIDTH + overlap,
                             TILE_HEIGHT + overlap,
                             FilterType::CatmullRom,
                         );
+                        tile_image
+                            .as_mut_rgba8()
+                            .unwrap()
+                            .pixels_mut()
+                            .for_each(|p| p[3] = p[2]);
                         overlay(base_image, &tile_image, x - overlap / 2, y - overlap / 2);
                     }
                     PlacedTile::ChainTop => {

--- a/src/grid_renderer.rs
+++ b/src/grid_renderer.rs
@@ -483,12 +483,33 @@ impl GridRenderer {
                             TILE_WIDTH,
                             TILE_HEIGHT,
                         );
-                        overlay(
-                            base_image,
-                            &tile_image,
-                            x - TILE_WIDTH / 2,
-                            y - TILE_HEIGHT + 18,
-                        );
+                        if *biome == Biome::Volcana && !placed_egg && rng.gen_bool(0.3) {
+                            let precious_image = &load_images(CHAR_PRECIOUS, CLASSIC_CHAR_PRECIOUS)
+                                [if self.classic_mode { 1 } else { 0 }];
+
+                            overlay(
+                                base_image,
+                                precious_image,
+                                x - TILE_WIDTH + 8,
+                                y - TILE_HEIGHT + 8,
+                            );
+
+                            overlay(
+                                base_image,
+                                &tile_image,
+                                x - TILE_WIDTH / 2,
+                                y - TILE_HEIGHT + 13,
+                            );
+
+                            placed_egg = true;
+                        } else {
+                            overlay(
+                                base_image,
+                                &tile_image,
+                                x - TILE_WIDTH / 2,
+                                y - TILE_HEIGHT + 18,
+                            );
+                        }
                     }
                     PlacedTile::EggplantAltarLeft => {
                         place_tile(biome_sheet, 11, 2);
@@ -572,17 +593,10 @@ impl GridRenderer {
                     }
                     PlacedTile::IceBlock => {
                         if !placed_egg && rng.gen_bool(0.2) {
-                            let beg_image = load_from_memory_with_format(
-                                if self.classic_mode {
-                                    CLASSIC_CHAR_BEG
-                                } else {
-                                    CHAR_BEG
-                                },
-                                Png,
-                            )
-                            .unwrap();
+                            let beg_image = &load_images(CHAR_BEG, CLASSIC_CHAR_BEG)
+                                [if self.classic_mode { 1 } else { 0 }];
 
-                            overlay(base_image, &beg_image, x, y);
+                            overlay(base_image, beg_image, x, y);
 
                             placed_egg = true;
                         }

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,10 +1,11 @@
-use std::collections::HashMap;
 use std::convert::Infallible;
 use std::future::Future;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
+
+use multimap::MultiMap;
 
 use hyper::header::{HeaderValue, CONTENT_TYPE};
 use hyper::service::Service;
@@ -72,7 +73,7 @@ impl Service<Request<Body>> for IconService {
             return Box::pin(async { Ok(response) });
         }
 
-        let params: HashMap<String, String> = req
+        let params: MultiMap<String, String> = req
             .uri()
             .query()
             .map(|v| {
@@ -80,7 +81,7 @@ impl Service<Request<Body>> for IconService {
                     .into_owned()
                     .collect()
             })
-            .unwrap_or_else(HashMap::new);
+            .unwrap_or_else(MultiMap::new);
 
         let size = params
             .get("size")
@@ -105,7 +106,7 @@ impl Service<Request<Body>> for IconService {
             }
         };
 
-        let egg = params.get("egg").cloned();
+        let egg = params.get_vec("egg").cloned();
 
         // Generate the PNG
         let config = Spelunkicon::from_input(&input, egg, size, max_misc);

--- a/src/sheets.rs
+++ b/src/sheets.rs
@@ -6,6 +6,7 @@ use crate::grid_generator::*;
 use crate::grid_renderer::{GridRenderer, Sheets};
 use crate::spelunkicon::Spelunkicon;
 
+#[derive(PartialEq)]
 pub enum Biome {
     Cave,
     Jungle,

--- a/src/sheets.rs
+++ b/src/sheets.rs
@@ -56,6 +56,7 @@ impl GenSheet {
         base_image: &mut RgbaImage,
         sheets: &Sheets,
         config: &Spelunkicon,
+        classic_mode: bool,
         rng: &mut StdRng,
     ) {
         match self {
@@ -64,7 +65,7 @@ impl GenSheet {
                 let floor = generator.place_floor_tiles(biome, config, rng);
                 let floor = generator.place_floormisc_tiles(biome, config, rng, floor);
 
-                let renderer = GridRenderer {};
+                let renderer = GridRenderer::new(classic_mode);
                 renderer.render_floor_tiles(base_image, sheets, biome, config, rng, &floor);
                 renderer.render_floormisc_tiles(base_image, sheets, biome, config, rng, &floor);
                 renderer.render_floor_decorations(base_image, sheets, biome, config, rng, &floor);
@@ -75,7 +76,7 @@ impl GenSheet {
                 let floor = generator.place_floorstyled_tiles(biome, config, rng, None);
                 let floor = generator.place_floormisc_tiles(biome, config, rng, floor);
 
-                let renderer = GridRenderer {};
+                let renderer = GridRenderer::new(classic_mode);
                 renderer.render_floorstyled_tiles(base_image, sheets, biome, config, rng, &floor);
                 renderer.render_floormisc_tiles(base_image, sheets, biome, config, rng, &floor);
             }
@@ -85,7 +86,7 @@ impl GenSheet {
                 let floor = generator.place_floorstyled_tiles(biome, config, rng, Some(floor));
                 let floor = generator.place_floormisc_tiles(biome, config, rng, floor);
 
-                let renderer = GridRenderer {};
+                let renderer = GridRenderer::new(classic_mode);
                 renderer.render_floor_tiles(base_image, sheets, biome, config, rng, &floor);
                 renderer.render_floorstyled_tiles(base_image, sheets, biome, config, rng, &floor);
                 renderer.render_floormisc_tiles(base_image, sheets, biome, config, rng, &floor);
@@ -93,7 +94,7 @@ impl GenSheet {
                 renderer.render_floor_embeds(base_image, sheets, config, rng, &floor);
             }
             GenSheet::Pride() => {
-                let renderer = PrideRenderer {};
+                let renderer = PrideRenderer::new(classic_mode);
                 renderer.render(base_image, sheets, config, rng);
             }
         }

--- a/src/spelunkicon.rs
+++ b/src/spelunkicon.rs
@@ -6,13 +6,13 @@ pub struct Spelunkicon {
     pub grid_height: u8,
     pub max_misc: u8,
     pub input: String,
-    pub egg: Option<String>,
+    pub egg: Option<Vec<String>>,
     pub hash: u32,
     pub grid: Vec<Vec<bool>>,
 }
 
 impl Spelunkicon {
-    pub fn from_input(input: &str, egg: Option<String>, height: u8, max_misc: u8) -> Self {
+    pub fn from_input(input: &str, egg: Option<Vec<String>>, height: u8, max_misc: u8) -> Self {
         let grid_width = height;
         let grid_height = height;
 


### PR DESCRIPTION
Either randomly output an spelunkicon with classic textures (currently at 1%) or manually via `egg=classic`. Maybe we want a bit lower chance?

Stacks with other `egg=` options by supplying multiple, e.g. `egg=pride&egg=classic`. This introduced the `multimap` dependency, not sure if there's a better way to do this without that dep.

Requires putting the images from the "Spelunky 2 Retrofied" mod into `target/ClassicTextures`. Is there some way to run different build paths for whether that folder is available or not? So that way it would not be a requirement for building.