### PR TITLE
Add support for low-res images in Debug builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,4 @@ url = "2.2.2"
 
 [build-dependencies]
 image = "0.23.14"
+num-rational = "0.4.0"

--- a/README.md
+++ b/README.md
@@ -4,8 +4,26 @@ Generate Spelunky Identicons
 
 ## Building
 
-Copy textures from your extracted assets into `target/Textures`.
+Copy textures from your extracted assets, i.e. `Mods/Extracted/Data/Textures`, into `target/Textures`. Also copy textures from the [Spelunky 2 Retrofied](https://spelunky.fyi/mods/m/retro/) mod into `target/ClassicTextures`.
 
-```
+```sh
 cargo build --release
 ```
+
+## Debugging
+
+To debug, run the service locally, then open a browser and enter a URL, e.g. `http://127.0.0.1:3000/example.png?size=7&egg=classic`, the result will be served directly to your browser. To run the service:
+
+```sh
+cargo run --release
+```
+
+Running in Debug mode (i.e. `cargo run`) is required for setting breakpoints. However loading all textures in debug mode is very slow. To speed up debug builds resize all images into the folders `Textures/LowRes` and `ClassicTextures/LowRes` respectively. Ideally scale by a multiple of a half, e.g.
+
+```sh
+cd target/Textures
+mkdir LowRes
+magick mogrify -resize 12.5% -quality 100 -filter Point -path ./LowRes *.png
+```
+
+The `LowRes` folder is only used in Debug builds, not in Release builds.

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,2 +1,4 @@
-pub(crate) const TILE_WIDTH: u32 = 128;
-pub(crate) const TILE_HEIGHT: u32 = 128;
+use crate::pngs;
+
+pub(crate) const TILE_WIDTH: u32 = pngs::TILE_WIDTH;
+pub(crate) const TILE_HEIGHT: u32 = pngs::TILE_HEIGHT;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -2,3 +2,4 @@ use crate::pngs;
 
 pub(crate) const TILE_WIDTH: u32 = pngs::TILE_WIDTH;
 pub(crate) const TILE_HEIGHT: u32 = pngs::TILE_HEIGHT;
+pub(crate) const OUTPUT_DIMENSION: u32 = 250;

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -7,12 +7,10 @@ use rand::prelude::StdRng;
 use rand::prelude::*;
 use rand::SeedableRng;
 
-use crate::constants::{TILE_HEIGHT, TILE_WIDTH};
+use crate::constants::{OUTPUT_DIMENSION, TILE_HEIGHT, TILE_WIDTH};
 use crate::grid_renderer::Sheets;
 use crate::sheets::{Biome, GenKind, GenSheet};
 use crate::spelunkicon::Spelunkicon;
-
-const OUTPUT_DIMENSION: u32 = 250;
 
 pub struct Generator {
     pub sheets: Sheets,


### PR DESCRIPTION
Now `build.rs` pulls from `target/Textures/LowRes` if available. It assumes all images inside are scaled down (or technically also allows upscaled images) equally. It infers from `floor_cave.png` the right scaling and adjusts `TILE_WIDTH` and `TILE_HEIGHT` accordingly. As such it also allows to scale the base images if you would want to waifu2x them for Release mode.

Also updated the README with some more instructions on usage, including a simple command line for resizing images.